### PR TITLE
Fixed cleaver sticking bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,124 @@ build.sh
 StormTweaks/libs
 build
 MassiveFraud.zip
+StormTweaks/*.dll
+
+## Standard Visual Studio .gitignore defintions
+## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
+
+# User-specific files
+*.rsuser
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# User-specific files (MonoDevelop/Xamarin Studio)
+*.userprefs
+
+# Mono auto generated files
+mono_crash.*
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+[Ww][Ii][Nn]32/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Oo]ut/
+[Ll]og/
+[Ll]ogs/
+
+# Visual Studio 2015/2017 cache/options directory
+.vs/
+
+# Visual Studio 2017 auto generated files
+Generated\ Files/
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# NUnit
+*.VisualState.xml
+TestResult.xml
+nunit-*.xml
+
+# .NET Core
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+# Files built by Visual Studio
+*_i.c
+*_p.c
+*_h.h
+*.ilk
+*.meta
+*.obj
+*.iobj
+*.pch
+*.pdb
+*.ipdb
+*.pgc
+*.pgd
+*.rsp
+*.sbr
+*.tlb
+*.tli
+*.tlh
+*.tmp
+*.tmp_proj
+*_wpftmp.csproj
+*.log
+*.vspscc
+*.vssscc
+.builds
+*.pidb
+*.svclog
+*.scc
+
+# ReSharper is a .NET coding add-in
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.DotSettings.user
+
+# NuGet Packages
+*.nupkg
+# NuGet Symbol Packages
+*.snupkg
+# The packages folder can be ignored because of Package Restore
+**/[Pp]ackages/*
+# except build/, which is used as an MSBuild target.
+!**/[Pp]ackages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+# NuGet v3's project.json files produces more ignorable files
+*.nuget.props
+*.nuget.targets
+
+# Visual Studio cache files
+# files ending in .cache can be ignored
+*.[Cc]ache
+# but keep track of directories ending in .cache
+!?*.[Cc]ache/
+
+# Backup & report files from converting an old project file
+# to a newer Visual Studio version. Backup files are not needed,
+# because we have git ;-)
+_UpgradeReport_Files/
+Backup*/
+UpgradeLog*.XML
+UpgradeLog*.htm
+ServiceFabricBackup/
+*.rptproj.bak
+
+# MSBuild Binary and Structured Log
+*.binlog

--- a/README.md
+++ b/README.md
@@ -22,3 +22,12 @@ Tweaks some of the content added by Seekers of the Storm.
 
 ## Seeker
 - Meditation now deals 800% damage.
+
+## Build Instructions
+Visual Studio 2022 Community Edition with .NET standard 2.1 can be used to build this project.
+
+Additionally, please note that two Risk of Rain 2 official game assemblies need to be included within this project in order to build it from source. These two files are named `Decalicious.dll` and `Unity.Postprocessing.Runtime.dll`. You can find these assemblies within your game's installation directory. Example paths for these assemblies can be found below.
+ - `C:\Program Files (x86)\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\Decalicious.dll`
+ - `C:\Program Files (x86)\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\Unity.Postprocessing.Runtime.dll`
+
+Including these assemblies within the existing project directory at `StormTweaks/StormTweaks` (adjacent to `Plugin.cs`) should automatically include them within Visual Studio's build chain.

--- a/StormTweaks/CHEF/CHEF.cs
+++ b/StormTweaks/CHEF/CHEF.cs
@@ -238,7 +238,7 @@ namespace StormTweaks {
         {
             orig(self);
 
-            self.recallCleaver = self.cleaverAway && !self.characterBody.inputBank.skill1.down && ChefCleaverStorage.GetCanBodyRecall(self.characterBody);
+            self.recallCleaver = !self.characterBody.inputBank.skill1.down && ChefCleaverStorage.GetCanBodyRecall(self.characterBody);
         }
 
         private static void Dice_FixedUpdate(On.EntityStates.Chef.Dice.orig_FixedUpdate orig, Dice self)


### PR DESCRIPTION
The changes attached fix a bug where, after throwing two cleavers, if you happen to throw the third--by clicking and immediately releasing the input--right as the first two are returning, the final cleaver will stay stuck in the air and not return to the user. This is because `self.cleaverAway` does not accurately reflect the status of the final cleaver thrown. I'm not sure exactly why this is, but removing this check from the `ChefController_Update` function fixes the issue, and the final cleaver still reaches its maximum distance; as the `ChefCleaverStorage::GetCanBodyRecall` function continues to operate correctly.

Additionally, I have included an amendment to the project's `README.md` file which includes build instructions, and updated the `.gitignore` with a minimal version of [GitHub's official .gitignore definitions for Visual Studio](https://github.com/github/gitignore/blob/master/VisualStudio.gitignore).

Thank you for the work you put into this mod! It's been a lot of fun to play around with :)